### PR TITLE
Fix: #49 어제와 오늘 기록이 제대로 불러와지지 않는 오류 해결

### DIFF
--- a/gacha/gacha/ViewModels/MeasureViewModel+Progress.swift
+++ b/gacha/gacha/ViewModels/MeasureViewModel+Progress.swift
@@ -18,9 +18,18 @@ extension MeasureViewModel {
     // 가장 최근 기록(어제) 불러오기
     func loadPreviousRecord() async {
         previousRecord = await self.loadLatestRecord()
+        print("이전기록: \(previousRecord?.measuredDate.description ?? "없음")")
+    }
+    
+    // 오늘 기록을 currentRecord로 불러오기
+    func loadTodayRecord() async {
+        currentRecord = await self.loadLatestRecord()
+        print("이전기록: \(previousRecord?.measuredDate.description ?? "없음")")
     }
 
     func calculateRecordChange() {
+        print("🥹", currentRecord?.measuredDate.description ?? "없음")
+        print("🥹", previousRecord?.measuredDate.description ?? "없음")
         guard let current = currentRecord,
             let previous = previousRecord
         else {

--- a/gacha/gacha/ViewModels/MeasureViewModel.swift
+++ b/gacha/gacha/ViewModels/MeasureViewModel.swift
@@ -56,7 +56,6 @@ final class MeasureViewModel: ObservableObject {
     }
 
     func checkTodayRecord() async {
-        let record: MeasuredRecord? = nil
         isLoading = true
         defer { isLoading = false }
 
@@ -66,11 +65,12 @@ final class MeasureViewModel: ObservableObject {
             if hasTodayRecord {
                 currentRecord = await loadLatestRecord()
             }
+            print("📅 오늘의 기록: \(currentRecord?.measuredDate.description ?? "없음")")
+
         } catch {
             print("❌ 기록 확인 실패: \(error)")
             hasTodayRecord = false
         }
-        print("📅 오늘의 기록: \(record?.measuredDate.description ?? "없음")")
     }
 
     func startMeasuring() {
@@ -288,6 +288,27 @@ final class MeasureViewModel: ObservableObject {
             errorMessage = "최근 레코드 로드 실패: \(error.localizedDescription)"
             print("❌ \(errorMessage ?? "")")
             return nil
+        }
+    }
+    
+    // MARK: - 어제 레코드 불러오기
+    func loadYesterdayRecord() async {
+        isLoading = true
+        defer { isLoading = false }
+
+        do {
+            let records = try await repository.loadRecords()
+            let record = records.dropFirst().first
+            previousRecord = record
+
+            if let record = previousRecord {
+                print("📝 어제 레코드 로드: Extension \(record.measuredDate)°")
+            } else {
+                print("⚠️ 저장된 레코드가 없습니다")
+            }
+        } catch {
+            errorMessage = "어제 레코드 로드 실패: \(error.localizedDescription)"
+            print("❌ \(errorMessage ?? "")")
         }
     }
 

--- a/gacha/gacha/Views/DailyMeasureSummaryView.swift
+++ b/gacha/gacha/Views/DailyMeasureSummaryView.swift
@@ -16,73 +16,83 @@ struct DailyMeasureSummaryView: View {
 
     var body: some View {
         GeometryReader { geo in
-            VStack(spacing: 0) {
-                // MARK: - 상단 영역
-                VStack(alignment: .leading, spacing: 8) {
-                    HStack {
-                        Spacer()
+            if vm.isLoading {
+                Text("Loading...")
+            } else {
 
-                        ButtonComponent(
-                            background: Color("Primary300"),
-                            systemImageName: "chart.xyaxis.line",
-                            weight: .semibold,
-                            color: Color("White")
-                        ) {
-                            showHistorySheet = true
+                VStack(spacing: 0) {
+                    // MARK: - 상단 영역
+                    VStack(alignment: .leading, spacing: 8) {
+                        HStack {
+                            Spacer()
+
+                            ButtonComponent(
+                                background: Color("Primary300"),
+                                systemImageName: "chart.xyaxis.line",
+                                weight: .semibold,
+                                color: Color("White")
+                            ) {
+                                showHistorySheet = true
+                            }
+
                         }
 
+                        VStack(alignment: .leading, spacing: 8) {
+                            Text(Strings.Summary.title)
+                                .font(.displayLargeBold)
+                            Text(Strings.Summary.description)
+                                .font(.displayTitle3Medium)
+                        }
                     }
+                    .padding(.horizontal, 16)
 
-                    VStack(alignment: .leading, spacing: 8) {
-                        Text(Strings.Summary.title)
-                            .font(.displayLargeBold)
-                        Text(Strings.Summary.description)
-                            .font(.displayTitle3Medium)
+                    Spacer()
+
+                    // MARK: - 중간 영역
+                    resultCardWithMeasurements
+
+                    Spacer()
+
+                    CapsuleButtonComponent(
+                        title: Strings.Summary.button,
+                        style: .primary
+                    ) {
+                        showingAlert = true
+                    }
+                    .alert(isPresented: $showingAlert) {
+                        Alert(
+                            title: Text(Strings.Alert.Remeasure.title),
+                            message: Text(Strings.Alert.Remeasure.message),
+                            primaryButton: .destructive(
+                                Text("네"),
+                                action: {
+                                    vm.navigationPath.append(
+                                        MeasureFlowStep.extensionMeasure
+                                    )
+                                }
+                            ),
+                            secondaryButton: .cancel(Text("아니요"))
+                        )
                     }
                 }
-                .padding(.horizontal, 16)
-                
-                Spacer()
+                .frame(
+                    maxWidth: .infinity,
+                    maxHeight: .infinity,
+                    alignment: .top
+                )
+                .appBackground()
 
-                // MARK: - 중간 영역
-                resultCardWithMeasurements
-
-                Spacer()
-
-                CapsuleButtonComponent(
-                    title: Strings.Summary.button,
-                    style: .primary
-                ) {
-                    showingAlert = true
+                .sheet(isPresented: $showHistorySheet) {
+                    ProgressHistoryView()
+                        .presentationDetents([.large])
+                        .presentationDragIndicator(.hidden)
                 }
-                .alert(isPresented: $showingAlert) {
-                    Alert(
-                        title: Text(Strings.Alert.Remeasure.title),
-                        message: Text(Strings.Alert.Remeasure.message),
-                        primaryButton: .destructive(
-                            Text("네"),
-                            action: {
-                                vm.navigationPath.append(
-                                    MeasureFlowStep.extensionMeasure
-                                )
-                            }
-                        ),
-                        secondaryButton: .cancel(Text("아니요"))
-                    )
-                }
-            }
-            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
-            .appBackground()
-
-            .sheet(isPresented: $showHistorySheet) {
-                ProgressHistoryView()
-                    .presentationDetents([.large])
-                    .presentationDragIndicator(.hidden)
             }
         }
         .onAppear {
             Task {
-                await vm.loadPreviousRecord()
+                await vm.loadTodayRecord()
+                await vm.loadYesterdayRecord()
                 vm.calculateRecordChange()
             }
             vm.clearCurrentRecord()
@@ -104,28 +114,36 @@ struct DailyMeasureSummaryView: View {
                         .scaledToFill()
                         .frame(width: 115, height: 115)
                         .overlay(alignment: .topTrailing) {
-                            Text(vm.formatAngle(vm.currentRecord?.extensionAngle))
-                                .font(.title2)
-                                .fontWeight(.bold)
-                                .padding(.top, 8)
-                                .padding(.trailing, 8)
+                            Text(
+                                vm.formatAngle(
+                                    vm.currentRecord?.extensionAngle
+                                )
+                            )
+                            .font(.title2)
+                            .fontWeight(.bold)
+                            .padding(.top, 8)
+                            .padding(.trailing, 8)
                         }
                 }
-                
+
                 VStack(spacing: 8) {
                     Image("FlexionBody")
                         .resizable()
                         .scaledToFill()
                         .frame(width: 115, height: 115)
-                         .overlay(alignment: .topTrailing) {
-                            Text(vm.formatAngle(vm.currentRecord?.flexionAngle))
-                                .font(.title2)
-                                .fontWeight(.bold)
-                                .padding(.top, 8)
-                                .padding(.trailing, 8)
+                        .overlay(alignment: .topTrailing) {
+                            Text(
+                                vm.formatAngle(
+                                    vm.currentRecord?.flexionAngle
+                                )
+                            )
+                            .font(.title2)
+                            .fontWeight(.bold)
+                            .padding(.top, 8)
+                            .padding(.trailing, 8)
                         }
                 }
-                
+
             }
             .frame(maxWidth: .infinity, alignment: .center)
 
@@ -138,9 +156,9 @@ struct DailyMeasureSummaryView: View {
                     .foregroundStyle(.secondary)
             }
 
-            
             // 측정값 그리드
             measurementGrid
+
         }
         .padding(24)
         .frame(width: 345, alignment: .topLeading)
@@ -215,7 +233,8 @@ struct DailyMeasureSummaryView: View {
                         Image(
                             systemName: changeValue > 0
                                 ? "arrowtriangle.up.fill"
-                                : changeValue < 0 ? "arrowtriangle.down.fill" : "minus"
+                                : changeValue < 0
+                                    ? "arrowtriangle.down.fill" : "minus"
                         )
                         .font(.caption2)
                         Text("\(changeValue)°")


### PR DESCRIPTION
- 가장 최근 기록이 오늘이어서 발생하는 오류
- loadTodayRecord와 loadYesterdayRecord 생성

<!--
🙏 PR 제목 컨벤션 (Gitmoji + 타입 + 이슈 번호 + 작업 요약)
예시: ✨ Feature: #167 예약 취소 구현
※ PR 생성 시 Assignees 및 Labels 설정도 잊지 마세요!
-->

## ✨ What’s this PR?
### 📌 관련 이슈 (Related Issue)
<!-- 해당 PR이 어떤 이슈를 해결하는지 연결해주세요 -->
- Closes #49 

---

### 🧶 주요 변경 내용 (Summary)
<!-- 이번 PR에서 작업한 핵심 변경 사항을 작성해주세요 -->

- loadTodayRecord: 오늘의 데이터가 존재할 떄, 가장 최근 데이터 current로 불러오기
- loadYesterdayRecord: 오늘의 데이터가 존재할 떄, 2번쨰 최근 데이터 previous로 불러오기

---

### 📸 스크린샷 (Optional)
<!-- UI 작업의 경우, 구현한 화면을 첨부해주세요 -->
<!-- 이미지 크기 조절 예시: <img width="300" alt="설명" src="링크"> -->

<img width="300" height="800" alt="image" src="https://github.com/user-attachments/assets/2b071863-d5e6-4b54-b4d7-46c787491254" />

---

### 🧪 테스트 / 검증 내역
<!-- 동작 확인 여부나 시나리오 테스트 내용을 간단히 써주세요 -->

- [x] 빌드 및 런타임 오류 없음
- [x] 기기 테스트 완료
- [x] PR 제목 컨벤션 지킴
- [x] 불필요한 코드 제거
- [x] 리뷰 준비 완료