### PR TITLE
Bug #58 날짜 범위 에러

### DIFF
--- a/gacha/gacha/ViewModels/ProgressHistoryViewModel.swift
+++ b/gacha/gacha/ViewModels/ProgressHistoryViewModel.swift
@@ -30,13 +30,23 @@ class ProgressHistoryViewModel: ObservableObject {
     }
     
     var dateRangeText: String {
+        guard !recentRecords.isEmpty else { return "" }
+        
+        // 데이터가 1개인 경우
+        if recentRecords.count == 1,
+           let singleDate = recentRecords.first?.measuredDate {
+            let formatter = DateFormatter()
+            formatter.dateFormat = "yyyy/M/d"
+            return formatter.string(from: singleDate)
+        }
+        
+        // 데이터가 2개 이상인 경우
         guard let startDate = recentRecords.first?.measuredDate,
-            let endDate = recentRecords.last?.measuredDate
+              let endDate = recentRecords.last?.measuredDate
         else {
             return ""
         }
-        let formattedDate = formatDateRange(startDate: startDate, endDate: endDate)
-        return formattedDate
+        return formatDateRange(startDate: startDate, endDate: endDate)
     }
 
     var painMin: Int {
@@ -51,6 +61,22 @@ class ProgressHistoryViewModel: ObservableObject {
             return 0
         }
         return max
+    }
+    
+    var painLevelLabel: String {
+        if recentRecords.count == 1 {
+            return Strings.Card.painLevel
+        } else {
+            return Strings.History.painMin + "~" + Strings.History.painMax
+        }
+    }
+    
+    var painLevelValue: String {
+        if recentRecords.count == 1 {
+            return "\(painMin)"
+        } else {
+            return "\(painMin)~\(painMax)"
+        }
     }
 
     // MARK: - Helper Methods

--- a/gacha/gacha/Views/Progress/ProgressHistoryView.swift
+++ b/gacha/gacha/Views/Progress/ProgressHistoryView.swift
@@ -56,11 +56,11 @@ struct ProgressHistoryView: View {
                             
                             VStack(alignment: .leading) {
                                 VStack(alignment: .leading, spacing: 4) {
-                                    Text(Strings.History.painMin + "~" + Strings.History.painMax)
+                                    Text(vm.painLevelLabel)
                                         .font(.displayCaption1Semibold)
                                         .foregroundColor(Color("Gray500"))
 
-                                    Text("\(vm.painMin)~\(vm.painMax)")
+                                    Text(vm.painLevelValue)
                                         .font(.displayTitle1Bold)
                                 }
                                 


### PR DESCRIPTION
<!--
🙏 PR 제목 컨벤션 (Gitmoji + 타입 + 이슈 번호 + 작업 요약)
예시: ✨ Feature: #167 예약 취소 구현
※ PR 생성 시 Assignees 및 Labels 설정도 잊지 마세요!
-->

## ✨ What’s this PR?
### 📌 관련 이슈 (Related Issue)
<!-- 해당 PR이 어떤 이슈를 해결하는지 연결해주세요 -->
- Closes #58 

---

### 🧶 주요 변경 내용 (Summary)
<!-- 이번 PR에서 작업한 핵심 변경 사항을 작성해주세요 -->

`ProgressHistoryViewModel.swift`
1. dateRangeText 수정
데이터 1개: "2025/11/3" 형식으로 단일 날짜 표시
데이터 2개 이상: "2025/11/1~3" 형식으로 범위 표시

2. painLevelLabel 추가
데이터 1개: "Pain Level" (영어) / "통증 수준" (한글)
데이터 2개 이상: "Min\~Max" / "최소~최대"

3. painLevelValue 추가
데이터 1개: "5" (단일 값)
데이터 2개 이상: "3~7" (범위)

`ProgressHistoryView.swift`
1. 통증 수준 차트에서 하드코딩된 텍스트를 ViewModel의 computed property로 교체

---


### 🧪 테스트 / 검증 내역
<!-- 동작 확인 여부나 시나리오 테스트 내용을 간단히 써주세요 -->

- [x] 빌드 및 런타임 오류 없음
- [x] 기기 테스트 완료
- [x] PR 제목 컨벤션 지킴
- [x] 불필요한 코드 제거
- [x] 리뷰 준비 완료

---