### PR TITLE
Feature: #88 통증 기록 취소 시 분기 처리 및 각도만 저장 기능

### DIFF
--- a/gacha/gacha/LocalStrings.swift
+++ b/gacha/gacha/LocalStrings.swift
@@ -97,6 +97,9 @@ enum Strings {
             static var message: String {
                 NSLocalizedString("alert.cancel_pain.message", comment: "")
             }
+            static var messageFromHome: String {
+                NSLocalizedString("alert.cancel_pain_from_home.message", comment: "")
+            }
         }
     }
     

--- a/gacha/gacha/Models/MeasureFlowStep.swift
+++ b/gacha/gacha/Models/MeasureFlowStep.swift
@@ -14,3 +14,25 @@ enum MeasureFlowStep: Hashable {
     case painLevel  // PainLevel
     case summary  // MainViewAfter (측정 완료)
 }
+
+/// 네비게이션 소스 - 각 화면으로 진입한 경로를 추적
+enum NavigationSource: Hashable {
+    case home              // 홈 화면에서 직접 진입
+    case flexionMeasure    // 굴곡 측정 화면에서 진입
+    case flexionCheck      // 측정 확인 화면에서 진입
+    case painLevel         // 통증 레벨 화면에서 진입
+    case summary           // 결과 화면에서 진입
+    case calendar          // 캘린더에서 진입
+    case history           // 히스토리에서 진입
+    
+    /// 현재 단계로부터 소스를 추론하는 헬퍼
+    static func from(step: MeasureFlowStep) -> NavigationSource {
+        switch step {
+        case .home: return .home
+        case .flexionMeasure: return .flexionMeasure
+        case .flexionCheck: return .flexionCheck
+        case .painLevel: return .painLevel
+        case .summary: return .summary
+        }
+    }
+}

--- a/gacha/gacha/ViewModels/MeasureViewModel+Progress.swift
+++ b/gacha/gacha/ViewModels/MeasureViewModel+Progress.swift
@@ -234,7 +234,7 @@ extension MeasureViewModel {
     }
 
     func formatPainLevel(_ level: Int?) -> String {
-        guard let level = level else { return "0" }
+        guard let level = level else { return "-" }
         return "\(level)"
     }
 

--- a/gacha/gacha/ViewModels/MeasureViewModel.swift
+++ b/gacha/gacha/ViewModels/MeasureViewModel.swift
@@ -24,6 +24,11 @@ final class MeasureViewModel: ObservableObject {
     @Published var isLoading = false
     @Published var errorMessage: String? = nil
 
+    // MARK: - Navigation Source Tracking
+    /// 현재 화면으로 진입한 소스를 추적
+    /// 예: PainLevel 화면에서 이전 화면이 홈인지 측정 화면인지 확인
+    @Published var navigationSource: [MeasureFlowStep: NavigationSource] = [:]
+
     // MARK: - Progress Properties
     @Published var previousRecord: MeasuredRecord?
     @Published var changeResult: ChangeResult?
@@ -300,7 +305,37 @@ final class MeasureViewModel: ObservableObject {
         // 기록된 각도 데이터 정리
         measureManager.recordedAngles.removeAll()
         
+        // 네비게이션 소스도 초기화
+        clearAllNavigationSources()
+        
         print("🔄 [MeasureViewModel] 새 측정 준비 완료")
+    }
+    
+    // MARK: - Navigation Source Management
+    /// 특정 단계로의 네비게이션 소스 가져오기
+    func getNavigationSource(for step: MeasureFlowStep) -> NavigationSource? {
+        return navigationSource[step]
+    }
+    
+    /// 네비게이션 소스 설정
+    func setNavigationSource(for step: MeasureFlowStep, source: NavigationSource) {
+        navigationSource[step] = source
+    }
+    
+    /// 네비게이션 소스 초기화
+    func clearNavigationSource(for step: MeasureFlowStep) {
+        navigationSource.removeValue(forKey: step)
+    }
+    
+    /// 네비게이션 소스 전체 초기화
+    func clearAllNavigationSources() {
+        navigationSource.removeAll()
+    }
+    
+    /// 소스를 기록하며 네비게이션
+    func navigate(to step: MeasureFlowStep, from source: NavigationSource) {
+        setNavigationSource(for: step, source: source)
+        navigationPath.append(step)
     }
 
     // MARK: - Flexion 측정 완료 시
@@ -316,7 +351,8 @@ final class MeasureViewModel: ObservableObject {
         currentRecord = record
         print("✅ Flexion: \(record.flexionAngle)°")
 
-        navigationPath.append(MeasureFlowStep.painLevel)
+        // 소스를 기록하며 네비게이션 (측정 화면에서 PainLevel로 이동)
+        navigate(to: MeasureFlowStep.painLevel, from: NavigationSource.flexionMeasure)
     }
 
     // MARK: - PainLevel 측정 완료 시

--- a/gacha/gacha/Views/DashBoard/CalendarRecordModal.swift
+++ b/gacha/gacha/Views/DashBoard/CalendarRecordModal.swift
@@ -67,7 +67,7 @@ struct CalendarRecordModal: View {
                 Text(Strings.Progress.painLevel)
                     .font(.displayCalloutBold)
                     .foregroundColor(.blue700)
-                Text("\(record.painLevel ?? 0)")
+                Text(formatPainLevelForDisplay(record.painLevel))
                     .font(.displayTitle2Bold)
             }
 
@@ -105,6 +105,11 @@ struct CalendarRecordModal: View {
             return "-"
         }
         return "\(Int(angle))°"
+    }
+    
+    private func formatPainLevelForDisplay(_ level: Int?) -> String {
+        guard let level = level else { return "-" }
+        return "\(level)"
     }
 
     private var flexionImageName: String {

--- a/gacha/gacha/Views/DashBoard/History.swift
+++ b/gacha/gacha/Views/DashBoard/History.swift
@@ -271,7 +271,7 @@ struct History: View {
                     .foregroundStyle(Color("Gray700"))
                     .frame(maxWidth: .infinity, alignment: .topLeading)
 
-                Text("\(selectedRecord.painLevel ?? 0)")
+                Text(formatPainLevel(selectedRecord.painLevel))
                 .font(.displayTitle2Semibold)
                     .foregroundStyle(Color("Gray900"))
                     .frame(maxWidth: .infinity, alignment: .topLeading)
@@ -441,6 +441,12 @@ struct History: View {
         .frame(width: 173, height: 173)
         .background(Color.white)
         .cornerRadius(15)
+    }
+    
+    // MARK: - Helper Methods
+    private func formatPainLevel(_ level: Int?) -> String {
+        guard let level = level else { return "-" }
+        return "\(level)"
     }
 }
 

--- a/gacha/gacha/Views/DashBoard/MainViewAfter.swift
+++ b/gacha/gacha/Views/DashBoard/MainViewAfter.swift
@@ -123,7 +123,7 @@ struct MainViewAfter: View {
                 Text(Strings.Progress.painLevel)
                     .font(.displayCalloutBold)
                     .foregroundColor(.blue700)
-                Text("\(vm.currentRecord?.painLevel ?? 0)")
+                Text(vm.formatPainLevel(vm.currentRecord?.painLevel))
                     .font(.displayTitle2Bold)
             }
             

--- a/gacha/gacha/Views/Measure/FlexionMeasure.swift
+++ b/gacha/gacha/Views/Measure/FlexionMeasure.swift
@@ -60,8 +60,8 @@ struct FlexionMeasure: View {
                         }
                         .alert(isPresented: $showingAlert) {
                             Alert(
-                                title: Text(Strings.Alert.CancelPain.title),
-                                message: Text(Strings.Alert.CancelPain.message),
+                                title: Text(Strings.Alert.cancelFlexionHeadline),
+                                message: Text(Strings.Alert.quitExtensionMessage),
                                 primaryButton: .destructive(
                                     Text(Strings.Common.yes),
                                     action: {

--- a/gacha/gacha/Views/Measure/MainViewBefore.swift
+++ b/gacha/gacha/Views/Measure/MainViewBefore.swift
@@ -77,13 +77,15 @@ struct MainViewBefore: View {
                         cornerRadius: 100
                     ) {
                         vm.shouldAutoStartMeasure = true
-                        vm.navigationPath.append(MeasureFlowStep.flexionMeasure)
+                        // 홈에서 FlexionMeasure로 이동하는 경우 소스 기록
+                        vm.navigate(to: MeasureFlowStep.flexionMeasure, from: NavigationSource.home)
                     }
                 }
                 
                 // 보조 링크: "고통수치만 입력하기" (16px, 밑줄, Gray500)
                 Button(action: {
-                    vm.navigationPath.append(MeasureFlowStep.painLevel)
+                    // 홈에서 직접 PainLevel로 이동하는 경우 소스 기록
+                    vm.navigate(to: MeasureFlowStep.painLevel, from: NavigationSource.home)
                 }) {
                     Text(Strings.DailyStart.enterPainOnly)
                         .font(.displayBodyRegular)

--- a/gacha/gacha/Views/Measure/PainLevel.swift
+++ b/gacha/gacha/Views/Measure/PainLevel.swift
@@ -12,6 +12,23 @@ struct PainLevel: View {
     @State private var value: Double = 5.0  // 0~10 범위
     @State private var showingAlert = false
 
+    // 이전 화면이 홈인지 확인하는 computed property
+    private var isFromHome: Bool {
+        // navigationSource에서 현재 단계(.painLevel)의 소스를 확인
+        if let source = vm.getNavigationSource(for: .painLevel) {
+            return source == .home
+        }
+        // 소스가 기록되지 않은 경우 기본값 (안전하게 측정 화면에서 온 것으로 간주)
+        return false
+    }
+    
+    // Alert 메시지 분기
+    private var alertMessage: String {
+        isFromHome 
+            ? Strings.Alert.CancelPain.messageFromHome 
+            : Strings.Alert.CancelPain.message
+    }
+
     var body: some View {
         GeometryReader { geo in
             VStack(alignment: .center, spacing: 0) {
@@ -31,21 +48,38 @@ struct PainLevel: View {
                     .alert(isPresented: $showingAlert) {
                         Alert(
                             title: Text(Strings.Alert.CancelPain.title),
-                            message: Text(Strings.Alert.CancelPain.message),
+                            message: Text(alertMessage),  // 분기된 메시지 사용
                             primaryButton: .destructive(
                                 Text(Strings.Common.yes),
                                 action: {
-                                    // MainViewBefore로 이동 (측정 취소)
-                                    vm.prepareForNewMeasurement()  // 측정 상태 초기화
-                                    vm.clearCurrentRecord()        // 현재 레코드 클리어
                                     Task {
-                                        // 오늘 기록이 있다면 삭제 (이미 저장된 기록이 있을 수 있음)
-                                        await vm.deleteTodayRecords()
-                                        // 상태 업데이트 (hasTodayRecord = false)
-                                        await vm.checkTodayRecord()
+                                        if isFromHome {
+                                            // 홈에서 바로 온 경우: 아무것도 저장하지 않고 취소
+                                            vm.prepareForNewMeasurement()  // 측정 상태 초기화
+                                            vm.clearCurrentRecord()        // 현재 레코드 클리어
+                                            await vm.deleteTodayRecords()  // 오늘 기록 삭제
+                                            await vm.checkTodayRecord()    // 상태 업데이트
+                                        } else {
+                                            // 측정 후 온 경우: 각도만 저장 (통증 레벨은 저장하지 않음)
+                                            if let record = vm.currentRecord, record.flexionAngle != nil {
+                                                // 통증 레벨을 nil로 명시적으로 설정하여 각도만 저장되도록 보장
+                                                record.painLevel = nil
+                                                
+                                                // 각도만 저장 (통증 레벨 없음)
+                                                await vm.saveCurrentRecord()
+                                                print("✅ 각도만 저장됨: \(record.flexionAngle ?? 0)°")
+                                            } else {
+                                                // 각도가 없는 경우 레코드만 클리어
+                                                vm.clearCurrentRecord()
+                                            }
+                                            vm.prepareForNewMeasurement()  // 측정 상태 초기화
+                                            await vm.checkTodayRecord()    // 상태 업데이트
+                                        }
+                                        // 네비게이션 스택 전체 비우기
+                                        await MainActor.run {
+                                            vm.navigationPath = NavigationPath()
+                                        }
                                     }
-                                    // 네비게이션 스택 전체 비우기
-                                    vm.navigationPath = NavigationPath()
                                 }
                             ),
                             secondaryButton: .cancel(Text(Strings.Common.no))

--- a/gacha/gacha/en.lproj/Localizable.strings
+++ b/gacha/gacha/en.lproj/Localizable.strings
@@ -28,8 +28,9 @@
 "alert.quit_extension.message" = "Return to home";
 "alert.cancel_pain.headline" = "Cancel pain record?";
 "alert.cancel_pain.message" = "Only knee flexion angle \nwill be recorded";
+"alert.cancel_pain_from_home.message" = "Return to home";
 "alert.remeasure.headline" = "Measure Again?";
-"alert.remeasure.message" = "The new data will be updated and saved as today’s record";
+"alert.remeasure.message" = "The new data will be updated and saved as today's record";
 
 /* MeasureView(Before) - 1/2 */
 "daily_start.title_large" = "Measure";

--- a/gacha/gacha/ko.lproj/Localizable.strings
+++ b/gacha/gacha/ko.lproj/Localizable.strings
@@ -28,6 +28,7 @@
 "alert.quit_extension.message" = "처음 화면으로 되돌아가요";
 "alert.cancel_pain.headline" = "통증 기록을 취소하시겠어요?";
 "alert.cancel_pain.message" = "무릎 굽힘 각도만 기록되고, 처음 화면으로 되돌아가요";
+"alert.cancel_pain_from_home.message" = "처음 화면으로 되돌아가요";
 "alert.remeasure.headline" = "다시 측정하시겠어요?";
 "alert.remeasure.message" = "새로 측정한 내용이 오늘의 기록으로 업데이트되어 저장돼요.";
 


### PR DESCRIPTION
- 이전 화면 경로를 추적하는 `NavigationSource`를 추가하여 화면 진입 경로를 관리합니다.
- 측정 화면을 거쳐 통증 입력 화면으로 진입한 경우, '취소' 시 각도 데이터만 저장되도록 로직을 수정했습니다.
- 홈 화면에서 통증 입력으로 바로 진입한 경우, '취소' 시 아무 데이터도 저장되지 않습니다.
-  통증 데이터가 없는 경우(nil), UI에 '0'이 아닌 '-'로 표시되도록 수정했습니다.

<!--
🙏 PR 제목 컨벤션 (Gitmoji + 타입 + 이슈 번호 + 작업 요약)
예시: ✨ Feature: #167 예약 취소 구현
※ PR 생성 시 Assignees 및 Labels 설정도 잊지 마세요!
-->

## ✨ What’s this PR?
### 📌 관련 이슈 (Related Issue)
<!-- 해당 PR이 어떤 이슈를 해결하는지 연결해주세요 -->
- Closes #88

---

### 🧶 주요 변경 내용 (Summary)
<!-- 이번 PR에서 작업한 핵심 변경 사항을 작성해주세요 -->

 - '각도만 저장' 기능 추가: 이제 사용자가 각도 측정 후 통증 
     입력을 취소해도, 측정된 각도 데이터는 저장됩니다. (통증 
     레벨은 nil로 기록)
 - 취소 동작 분기 처리: '통증 기록' 화면에서 '취소' 버튼을 
     눌렀을 때, 이전 화면이 어디였는지에 따라 동작이 달라집니다.
  - 측정 화면 → 통증 기록 → 취소: 각도 데이터만 저장 후 홈으로 
       이동합니다.
  - 홈 → 통증 기록 → 취소: 아무것도 저장하지 않고 홈으로 
       이동합니다.
 - UI 업데이트: 통증 기록이 없는 측정 데이터는 앱 내의 다른 
     화면(기록, 요약 등)에서 '0'이 아닌 '-'로 명확하게 표시됩니다.
---


### 🧪 테스트 / 검증 내역
<!-- 동작 확인 여부나 시나리오 테스트 내용을 간단히 써주세요 -->

- [x] 빌드 및 런타임 오류 없음
- [x] 기기 테스트 완료
- [x] PR 제목 컨벤션 지킴
- [x] 불필요한 코드 제거
- [x] 리뷰 준비 완료

