### PR TITLE
🎨 Design: 요약뷰에서 ROM card 2회 미만시 문구 추가

### DIFF
--- a/gacha/gacha/LocalStrings.swift
+++ b/gacha/gacha/LocalStrings.swift
@@ -438,6 +438,14 @@ enum Strings {
         static func romChangeDecreased(days: Int, degrees: Int) -> String {
             String(format: NSLocalizedString("history.rom_change_decreased", comment: ""), days, degrees)
         }
+        
+        static func romUnder2Emphasized(days: Int) -> String {
+            String(format: NSLocalizedString("history.rom_change_under2_emphasized", comment: ""), days)
+        }
+        
+        static var romUnder2: String {
+            NSLocalizedString("history.rom_change_under2", comment: "")
+        }
 
         static func painChangeDecreased(levels: Int) -> String {
             String(format: NSLocalizedString("history.pain_change_decreased", comment: ""), levels)
@@ -445,17 +453,6 @@ enum Strings {
         
         static func painChangeIncreased(levels: Int) -> String {
             String(format: NSLocalizedString("history.pain_change_increased", comment: ""), levels)
-        }
-    }
-    
-    enum HistoryRomUnder2 {
-        struct RomUnder2Parts {
-            func emphasized(days: Int) -> String {
-                let format = NSLocalizedString("history.rom_change_under2_emphasized", comment: "")
-                return String(format: format, "\(days)")
-            }
-                
-            let part2: String = NSLocalizedString("history.rom_change_under2", comment: "")
         }
     }
 }

--- a/gacha/gacha/LocalStrings.swift
+++ b/gacha/gacha/LocalStrings.swift
@@ -404,7 +404,10 @@ enum Strings {
             NSLocalizedString("history.rom_semibold15_worse", comment: "")
         }
         static var romNoRecord: String {
-            NSLocalizedString("history.semibold15_norecord", comment: "")
+            NSLocalizedString("history.rom_semibold15_norecord", comment: "")
+        }
+        static var rom1Record: String {
+            NSLocalizedString("history.rom_semibold15_1record", comment: "")
         }
         
         static var painTitle: String {
@@ -422,6 +425,10 @@ enum Strings {
         static var painNoRecord: String {
             NSLocalizedString("history.pain_semibold15_norecord", comment: "")
         }
+        static var pain1Record: String {
+            NSLocalizedString("history.pain_semibold15_1record", comment: "")
+        }
+
         
         // MARK: - History Summary Card Changes
         static func romChangeIncreased(days: Int, degrees: Int) -> String {

--- a/gacha/gacha/LocalStrings.swift
+++ b/gacha/gacha/LocalStrings.swift
@@ -438,13 +438,24 @@ enum Strings {
         static func romChangeDecreased(days: Int, degrees: Int) -> String {
             String(format: NSLocalizedString("history.rom_change_decreased", comment: ""), days, degrees)
         }
-        
+
         static func painChangeDecreased(levels: Int) -> String {
             String(format: NSLocalizedString("history.pain_change_decreased", comment: ""), levels)
         }
         
         static func painChangeIncreased(levels: Int) -> String {
             String(format: NSLocalizedString("history.pain_change_increased", comment: ""), levels)
+        }
+    }
+    
+    enum HistoryRomUnder2 {
+        struct RomUnder2Parts {
+            func emphasized(days: Int) -> String {
+                let format = NSLocalizedString("history.rom_change_under2_emphasized", comment: "")
+                return String(format: format, "\(days)")
+            }
+                
+            let part2: String = NSLocalizedString("history.rom_change_under2", comment: "")
         }
     }
 }

--- a/gacha/gacha/en.lproj/Localizable.strings
+++ b/gacha/gacha/en.lproj/Localizable.strings
@@ -132,7 +132,7 @@
 "history.pain_subheadline_same" = "Pain level has remained steady";
 "history.pain_subheadline_worse" = "Pain increased by nn steps since the start";
 "history.pain_subheadline_norecord" = "Make your first record. Track your body’s changes with Anggle!";
-"history.pain_subheadline_1record" = "You’ve made your first record.Anggle cheers you on in your first step toward recovery!";
+"history.pain_subheadline_1record" = "Great first step!\nAnggle is cheering for you!";
 
 "history.rom_title" = "Flexion range";
 "history.rom_semibold15_better" = "You can flex (nn)° more than previous (nnn)°";

--- a/gacha/gacha/en.lproj/Localizable.strings
+++ b/gacha/gacha/en.lproj/Localizable.strings
@@ -151,8 +151,8 @@
 /* History Summary Card - ROM Change */
 "history.rom_change_increased" = "It has improved by %d° over the past %d days!";
 "history.rom_change_decreased" = "It has decreased by %d° over the past %d days.";
-"history.rom_change_under2_emphasized" = "Measure: (n)days";
-"history.rom_change_under2" = "Changes may appear after the 3rd day"
+"history.rom_change_under2_emphasized" = "Measure: %ddays";
+"history.rom_change_under2" = "Changes may appear after the 3rd day";
 
 /* History Summary Card - Pain Change */
 "history.pain_change_decreased" = "Pain erased by %d levels since the start!";

--- a/gacha/gacha/en.lproj/Localizable.strings
+++ b/gacha/gacha/en.lproj/Localizable.strings
@@ -151,6 +151,8 @@
 /* History Summary Card - ROM Change */
 "history.rom_change_increased" = "It has improved by %d° over the past %d days!";
 "history.rom_change_decreased" = "It has decreased by %d° over the past %d days.";
+"history.rom_change_under2_emphasized" = "Measure: (n)days";
+"history.rom_change_under2" = "Changes may appear after the 3rd day"
 
 /* History Summary Card - Pain Change */
 "history.pain_change_decreased" = "Pain erased by %d levels since the start!";

--- a/gacha/gacha/en.lproj/Localizable.strings
+++ b/gacha/gacha/en.lproj/Localizable.strings
@@ -138,13 +138,15 @@
 "history.rom_semibold15_better" = "You can flex (nn)° more than previous (nnn)°";
 "history.rom_semibold15_same" = "Same as the period’s max of (nnn)°";
 "history.rom_semibold15_worse" = "You moved (nnn)° less than previous (nnn)°";
-"history.semibold15_norecord" = "Take your first measurement";
+"history.rom_semibold15_norecord" = "Take your first measurement";
+"history.rom_semibold15_1record" = "Your knee can bend up to %d°";
 
 "history.pain_title" = "Pain Level";
 "history.pain_semibold15_better" = "Pain eased by (n) level from (nn)";
 "history.pain_semibold15_same" = "Same pain level as the previous lowest";
 "history.pain_semibold15_worse" = "Pain increased by (n) level from (nn)";
 "history.pain_semibold15_norecord" = "Make your first record";
+"history.pain_semibold15_1record" = "You’re feeling pain at level %d"
 
 /* History Summary Card - ROM Change */
 "history.rom_change_increased" = "It has improved by %d° over the past %d days!";

--- a/gacha/gacha/ko.lproj/Localizable.strings
+++ b/gacha/gacha/ko.lproj/Localizable.strings
@@ -151,8 +151,8 @@
 /* History Summary Card - ROM Change */
 "history.rom_change_increased" = "지난 %d일간\n무릎 굽힘 범위가\n%d도 늘어났어요!";
 "history.rom_change_decreased" = "지난 %d일간\n무릎 굽힘 범위가\n%d도 줄었어요";
-"history.rom_change_under2_emphasized" = "측정일수: (n)일";
-"history.rom_change_under2" = "3일째 측정부터 변화를 확인할 수 있어요"
+"history.rom_change_under2_emphasized" = "측정일수: %d일";
+"history.rom_change_under2" = "3일째 측정부터 변화를 확인할 수 있어요";
 
 /* History Summary Card - Pain Change */
 "history.pain_change_decreased" = "처음에 비해\n통증이\n%d단계 줄었어요!";

--- a/gacha/gacha/ko.lproj/Localizable.strings
+++ b/gacha/gacha/ko.lproj/Localizable.strings
@@ -138,13 +138,15 @@
 "history.rom_semibold15_better" = "이 기간 최대였던 nnn°보다 nnn° 더 움직일 수 있어요";
 "history.rom_semibold15_same" = "이 기간 최대였던 nnn°와 같아요";
 "history.rom_semibold15_worse" = "이 기간 최대였던 nnn°보다 nnn° 덜 움직여요";
-"history.semibold15_norecord" = "첫 측정을 완료해 주세요";
+"history.rom_semibold15_norecord" = "첫 측정을 완료해 주세요";
+"history.rom_semibold15_1record" = "현재 무릎이 %d°까지 굽혀지고 있어요";
 
 "history.pain_title" = "통증 정도";
 "history.pain_semibold15_better" = "이 기간 가장 낮았던  nn보다 n단계 덜 아파졌어요";
 "history.pain_semibold15_same" = "이기간 가장 낮았던 nn단계의 통증과 같아요";
 "history.pain_semibold15_worse" = "이 기간 가장 낮았던 nn보다 n단계 더 아파졌어요";
 "history.pain_semibold15_norecord" = "첫 기록을 남겨 주세요";
+"history.pain_semibold15_1record" = "현재 통증 정도는 %d단계예요"
 
 /* History Summary Card - ROM Change */
 "history.rom_change_increased" = "지난 %d일간\n무릎 굽힘 범위가\n%d도 늘어났어요!";

--- a/gacha/gacha/ko.lproj/Localizable.strings
+++ b/gacha/gacha/ko.lproj/Localizable.strings
@@ -151,6 +151,8 @@
 /* History Summary Card - ROM Change */
 "history.rom_change_increased" = "지난 %d일간\n무릎 굽힘 범위가\n%d도 늘어났어요!";
 "history.rom_change_decreased" = "지난 %d일간\n무릎 굽힘 범위가\n%d도 줄었어요";
+"history.rom_change_under2_emphasized" = "측정일수: (n)일";
+"history.rom_change_under2" = "3일째 측정부터 변화를 확인할 수 있어요"
 
 /* History Summary Card - Pain Change */
 "history.pain_change_decreased" = "처음에 비해\n통증이\n%d단계 줄었어요!";


### PR DESCRIPTION
 🎨 Design: 요약뷰에서 ROM card 2회 미만시 문구 추가
 🎨 Design: 요약뷰에서 ROM, 통증 측정 1회시 문구 추가
 🎨 Design: 요약뷰에서 통증 카드 측정 1회시 영문 줄임


- Closes #102

### 🧶 주요 변경 내용 (Summary)
- 요약뷰에서 ROM card 2회 미만시 문구 추가
- 요약뷰에서 ROM, 통증 측정 1회시 문구 추가
- 요약뷰에서 통증 카드 측정 1회시 영문 줄임

---

### 📸 스크린샷 (Optional)
<!-- UI 작업의 경우, 구현한 화면을 첨부해주세요 -->
<!-- 이미지 크기 조절 예시: <img width="300" alt="설명" src="링크"> -->

<img width="300" alt="예시 이미지" src="https://...">

---

### 🧪 테스트 / 검증 내역
<!-- 동작 확인 여부나 시나리오 테스트 내용을 간단히 써주세요 -->

- [ ] 빌드 및 런타임 오류 없음
- [ ] 기기 테스트 완료
- [ ] PR 제목 컨벤션 지킴
- [ ] 불필요한 코드 제거
- [ ] 리뷰 준비 완료

---

### 💬 기타 공유 사항
<!-- 리뷰어가 참고하면 좋을 정보, 고민했던 지점 등을 적어주세요 -->

- UI 컴포넌트 위치가 디자이너 시안과 다를 수 있어요 → 후속 PR에서 반영 예정
- API 에러 대응 로직은 공통 모듈화하는 작업과 함께 처리할 예정입니다

---

### 🙇🏻‍♀️ 리뷰 가이드 (선택)
<!-- 리뷰어가 중점적으로 보면 좋을 포인트가 있다면 알려주세요 -->

- `XxxViewModel.swift` 파일의 로직 분리 구조
- `NetworkManager.swift`의 공통 로직 처리 방식
