### PR TITLE
Fix: #98 요약뷰 분기별 처리

### DIFF
--- a/gacha/gacha/LocalStrings.swift
+++ b/gacha/gacha/LocalStrings.swift
@@ -372,6 +372,7 @@ enum Strings {
             NSLocalizedString("history.rom_subheadline_worse", comment: "")
         }
         
+        
         static var painHeadline: String {
             NSLocalizedString("history.pain_headline", comment: "")
         }
@@ -394,39 +395,39 @@ enum Strings {
         static var romTitle: String {
             NSLocalizedString("history.rom_title", comment: "")
         }
-        static var romBetter: String {
-            NSLocalizedString("history.rom_semibold15_better", comment: "")
+        static func romBetter(maxDegrees: Int, difference: Int) -> String {
+            String(format: NSLocalizedString("history.rom_semibold15_better", comment: ""), maxDegrees, difference)
         }
-        static var romSame: String {
-            NSLocalizedString("history.rom_semibold15_same", comment: "")
+        static func romSame(maxDegrees: Int) -> String {
+            String(format: NSLocalizedString("history.rom_semibold15_same", comment: ""), maxDegrees)
         }
-        static var romWorse: String {
-            NSLocalizedString("history.rom_semibold15_worse", comment: "")
+        static func romWorse(maxDegrees: Int, difference: Int) -> String {
+            String(format: NSLocalizedString("history.rom_semibold15_worse", comment: ""), maxDegrees, difference)
         }
         static var romNoRecord: String {
             NSLocalizedString("history.rom_semibold15_norecord", comment: "")
         }
-        static var rom1Record: String {
-            NSLocalizedString("history.rom_semibold15_1record", comment: "")
+        static func rom1Record(degrees: Int) -> String {
+            String(format: NSLocalizedString("history.rom_semibold15_1record", comment: ""), degrees)
         }
-        
+
         static var painTitle: String {
             NSLocalizedString("history.pain_title", comment: "")
         }
-        static var painBetter: String {
-            NSLocalizedString("history.pain_semibold15_better", comment: "")
+        static func painBetter(minLevel: Int, difference: Int) -> String {
+            String(format: NSLocalizedString("history.pain_semibold15_better", comment: ""), minLevel, difference)
         }
-        static var painSame: String {
-            NSLocalizedString("history.pain_semibold15_same", comment: "")
+        static func painSame(minLevel: Int) -> String {
+            String(format: NSLocalizedString("history.pain_semibold15_same", comment: ""), minLevel)
         }
-        static var painWorse: String {
-            NSLocalizedString("history.pain_semibold15_worse", comment: "")
+        static func painWorse(minLevel: Int, difference: Int) -> String {
+            String(format: NSLocalizedString("history.pain_semibold15_worse", comment: ""), minLevel, difference)
         }
         static var painNoRecord: String {
             NSLocalizedString("history.pain_semibold15_norecord", comment: "")
         }
-        static var pain1Record: String {
-            NSLocalizedString("history.pain_semibold15_1record", comment: "")
+        static func pain1Record(level: Int) -> String {
+            String(format: NSLocalizedString("history.pain_semibold15_1record", comment: ""), level)
         }
 
         

--- a/gacha/gacha/Models/MockRecordRepository.swift
+++ b/gacha/gacha/Models/MockRecordRepository.swift
@@ -62,17 +62,21 @@ final class MockRecordRepository: RecordRepository {
 
 extension MockRecordRepository {
     enum Scenario {
+        case noRecord               // 데이터 없음
         case singleRecord           // 기록 1개만
         case multipleRecordsPositive // ROM 증가, 통증 감소 (긍정적)
         case multipleRecordsNegative // ROM 감소, 통증 증가 (부정적)
         case sevenRecords23Days     // 7개 기록, 23일간
         case noChange               // 변화 없음
-        
+
         func createRecords() -> [MeasuredRecord] {
             let calendar = Calendar.current
             let today = Date()
             
             switch self {
+            case .noRecord:
+                return []
+
             case .singleRecord:
                 return [
                     MeasuredRecord(

--- a/gacha/gacha/ViewModels/HistoryViewModel.swift
+++ b/gacha/gacha/ViewModels/HistoryViewModel.swift
@@ -94,11 +94,46 @@ class HistoryViewModel: ObservableObject {
               change != 0 else {
             return ""
         }
-        
+
         if change > 0 {
             return Strings.History.romChangeIncreased(days: daysBetweenRecords, degrees: abs(change))
         } else {
             return Strings.History.romChangeDecreased(days: daysBetweenRecords, degrees: abs(change))
+        }
+    }
+
+    /// ROM 서브타이틀 (최근 일주일 이내 데이터와 오늘 데이터 비교)
+    var romSubtitle: String {
+        // 측정 기록이 없는 경우
+        guard !recentRecords.isEmpty else {
+            return Strings.History.romNoRecord
+        }
+
+        // 첫 측정인 경우
+        guard recentRecords.count > 1,
+              let todayROM = latestROM else {
+            guard let firstROM = latestROM else {
+                return Strings.History.romNoRecord
+            }
+            return Strings.History.rom1Record(degrees: firstROM)
+        }
+
+        // 최근 일주일 이내의 최대 ROM (오늘 제외)
+        let previousRecords = recentRecords.dropLast()
+        guard let maxPreviousROM = previousRecords.compactMap({ $0.flexionAngle }).max() else {
+            return Strings.History.rom1Record(degrees: todayROM)
+        }
+
+        let maxPreviousROMInt = Int(maxPreviousROM)
+        let difference = abs(todayROM - maxPreviousROMInt)
+
+        // 비교 (ROM은 클수록 좋음)
+        if Double(todayROM) > maxPreviousROM {
+            return Strings.History.romBetter(maxDegrees: maxPreviousROMInt, difference: difference)
+        } else if Double(todayROM) == maxPreviousROM {
+            return Strings.History.romSame(maxDegrees: maxPreviousROMInt)
+        } else {
+            return Strings.History.romWorse(maxDegrees: maxPreviousROMInt, difference: difference)
         }
     }
     
@@ -140,11 +175,45 @@ class HistoryViewModel: ObservableObject {
               change != 0 else {
             return ""
         }
-        
+
         if change > 0 {
             return Strings.History.painChangeDecreased(levels: abs(change))
         } else {
             return Strings.History.painChangeIncreased(levels: abs(change))
+        }
+    }
+
+    /// 통증 레벨 서브타이틀 (최근 일주일 이내 데이터와 오늘 데이터 비교)
+    var painSubtitle: String {
+        // 측정 기록이 없는 경우
+        guard !recentRecords.isEmpty else {
+            return Strings.History.painNoRecord
+        }
+
+        // 첫 측정인 경우
+        guard recentRecords.count > 1,
+              let todayPain = latestPainLevel else {
+            guard let firstPain = latestPainLevel else {
+                return Strings.History.painNoRecord
+            }
+            return Strings.History.pain1Record(level: firstPain)
+        }
+
+        // 최근 일주일 이내의 최소 통증 레벨 (오늘 제외, 통증은 낮을수록 좋음)
+        let previousRecords = recentRecords.dropLast()
+        guard let minPreviousPain = previousRecords.compactMap({ $0.painLevel }).min() else {
+            return Strings.History.pain1Record(level: todayPain)
+        }
+
+        let difference = abs(todayPain - minPreviousPain)
+
+        // 비교 (통증은 낮을수록 좋음)
+        if todayPain < minPreviousPain {
+            return Strings.History.painBetter(minLevel: minPreviousPain, difference: difference)
+        } else if todayPain == minPreviousPain {
+            return Strings.History.painSame(minLevel: minPreviousPain)
+        } else {
+            return Strings.History.painWorse(minLevel: minPreviousPain, difference: difference)
         }
     }
     

--- a/gacha/gacha/ViewModels/MeasureViewModel.swift
+++ b/gacha/gacha/ViewModels/MeasureViewModel.swift
@@ -474,6 +474,7 @@ final class MeasureViewModel: ObservableObject {
                 guard let record = legacyRecord else { return }
                 print("🗑️ deleteTodayRecords: ", record.measuredDate)
                 try await repository.deleteRecord(by: record.id)
+                currentRecord = nil
                 print("🗑️ 오늘의 레코드를 delete")
             }
         } catch {

--- a/gacha/gacha/Views/DashBoard/History.swift
+++ b/gacha/gacha/Views/DashBoard/History.swift
@@ -46,12 +46,19 @@ struct History: View {
                                     Text(Strings.History.romTitle)
                                         .font(.displayTitle3Bold)
                                         .id("romChart")
-                                    // SubTitle
-                                    Text(vm.romSubtitle)
+                                    if vm.chartData.isEmpty {
+                                        // 측정된 데이터가 없을 때
+                                        Text(Strings.History.romNoRecord)
+                                            .frame(maxWidth: .infinity, alignment: .leading)
+                                    } else {
+                                        // SubTitle
+                                        Text(vm.romSubtitle)
 
-                                    romChart
+                                        romChart
 
+                                    }
                                 }
+                                .frame(maxWidth: .infinity)
                                 .padding(16)
                                 .background(Color("White"))
                                 .cornerRadius(24)
@@ -59,17 +66,24 @@ struct History: View {
 
                             // MARK: - 통증 수준 추이
                             VStack(alignment: .leading, spacing: 16) {
-                                
+
                                 VStack(alignment: .leading, spacing: 8) {
                                     // Title
                                     Text(Strings.History.painTitle)
                                         .font(.displayTitle3Bold)
                                         .id("painChart")
-                                    // SubTitle
-                                    Text(vm.painSubtitle)
+                                    if vm.chartData.isEmpty {
+                                        // 측정된 데이터가 없을 때
+                                        Text(Strings.History.painNoRecord)
+                                            .frame(maxWidth: .infinity, alignment: .leading)
+                                    } else {
+                                        // SubTitle
+                                        Text(vm.painSubtitle)
 
-                                    painChart
+                                        painChart
+                                    }
                                 }
+                                .frame(maxWidth: .infinity)
                                 .padding(16)
                                 .background(Color("White"))
                                 .cornerRadius(24)
@@ -110,9 +124,10 @@ struct History: View {
                 )
                 .cornerRadius(4)
             }
-            
+
             if let selectedIndex = selectedIndex,
-               selectedIndex >= 0 && selectedIndex < data.count {
+                selectedIndex >= 0 && selectedIndex < data.count
+            {
                 RuleMark(x: .value("Selected", selectedIndex))
                     .foregroundStyle(Color("Gray300"))
                     .zIndex(-1)
@@ -129,17 +144,19 @@ struct History: View {
             }
         }
         .chartXAxis {
-            AxisMarks(position: .bottom, values: vm.chartIndicesAsDouble) { value in
+            AxisMarks(position: .bottom, values: vm.chartIndicesAsDouble) {
+                value in
                 if let doubleValue = value.as(Double.self) {
                     let index = Int(round(doubleValue))
                     // 정확한 인덱스 값인지 확인 (0.01 이내 오차 허용)
                     if abs(doubleValue - Double(index)) < 0.01,
-                       index >= 0 && index < vm.recentRecords.count {
+                        index >= 0 && index < vm.recentRecords.count
+                    {
                         let record = vm.recentRecords[index]
                         let dateStr = vm.formatShortDate(record.measuredDate)
                         AxisValueLabel {
                             Text(dateStr)
-                                .offset(x:-17)
+                                .offset(x: -17)
                         }
                     } else {
                         AxisGridLine()
@@ -167,27 +184,25 @@ struct History: View {
     @ViewBuilder
     private var romAnnotation: some View {
         if let selectedIndex = vm.selectedROMIndex,
-           selectedIndex >= 0 && selectedIndex < vm.recentRecords.count {
+            selectedIndex >= 0 && selectedIndex < vm.recentRecords.count
+        {
             let selectedRecord = vm.recentRecords[selectedIndex]
             VStack(alignment: .center, spacing: 4) {
                 Text(Strings.History.romHeadline)
                     .font(.displayCaption1Semibold)
                     .foregroundStyle(Color("Gray700"))
                     .frame(maxWidth: .infinity, alignment: .topLeading)
-                    
 
                 Text("\(Int(selectedRecord.flexionAngle ?? 0))°")
                     .font(.displayTitle2Semibold)
                     .foregroundStyle(Color("Gray900"))
                     .frame(maxWidth: .infinity, alignment: .topLeading)
-                
-
 
                 Text(vm.formatDate(selectedRecord.measuredDate))
                     .font(.displayCaption1Semibold)
                     .foregroundStyle(Color("Gray700"))
                     .frame(maxWidth: .infinity, alignment: .topLeading)
-                    
+
             }
             .padding(.horizontal, 8)
             .padding(.vertical, 4)
@@ -201,7 +216,7 @@ struct History: View {
         let data = vm.chartData
         let domain = vm.xAxisDomain
         let selectedIndex = vm.selectedPainIndex
-        
+
         return Chart {
             ForEach(data, id: \.record.id) { item in
                 LineMark(
@@ -218,9 +233,10 @@ struct History: View {
                 .foregroundStyle(Color("Blue500"))
                 .symbolSize(80)
             }
-            
+
             if let selectedIndex = selectedIndex,
-               selectedIndex >= 0 && selectedIndex < data.count {
+                selectedIndex >= 0 && selectedIndex < data.count
+            {
                 RuleMark(x: .value("Selected", selectedIndex))
                     .foregroundStyle(Color("Gray300"))
                     .zIndex(-1)
@@ -237,17 +253,19 @@ struct History: View {
             }
         }
         .chartXAxis {
-            AxisMarks(position: .bottom, values: vm.chartIndicesAsDouble) { value in
+            AxisMarks(position: .bottom, values: vm.chartIndicesAsDouble) {
+                value in
                 if let doubleValue = value.as(Double.self) {
                     let index = Int(round(doubleValue))
                     // 정확한 인덱스 값인지 확인 (0.01 이내 오차 허용)
                     if abs(doubleValue - Double(index)) < 0.01,
-                       index >= 0 && index < vm.recentRecords.count {
+                        index >= 0 && index < vm.recentRecords.count
+                    {
                         let record = vm.recentRecords[index]
                         let dateStr = vm.formatShortDate(record.measuredDate)
                         AxisValueLabel {
                             Text(dateStr)
-                                .offset(x:-17)
+                                .offset(x: -17)
                         }
                     } else {
                         AxisGridLine()
@@ -265,7 +283,8 @@ struct History: View {
     @ViewBuilder
     private var painAnnotation: some View {
         if let selectedIndex = vm.selectedPainIndex,
-           selectedIndex >= 0 && selectedIndex < vm.recentRecords.count {
+            selectedIndex >= 0 && selectedIndex < vm.recentRecords.count
+        {
             let selectedRecord = vm.recentRecords[selectedIndex]
             VStack(alignment: .leading, spacing: 4) {
                 Text(Strings.History.painTitle)
@@ -274,10 +293,9 @@ struct History: View {
                     .frame(maxWidth: .infinity, alignment: .topLeading)
 
                 Text(formatPainLevel(selectedRecord.painLevel))
-                .font(.displayTitle2Semibold)
+                    .font(.displayTitle2Semibold)
                     .foregroundStyle(Color("Gray900"))
                     .frame(maxWidth: .infinity, alignment: .topLeading)
-
 
                 Text(vm.formatDate(selectedRecord.measuredDate))
                     .font(.displayCaption1Semibold)
@@ -292,9 +310,9 @@ struct History: View {
             .clipShape(RoundedRectangle(cornerRadius: 8))
         }
     }
-    
+
     // MARK: - Summary Cards
-    
+
     @ViewBuilder
     private func romSummaryCard(proxy: ScrollViewProxy) -> some View {
         VStack {
@@ -383,12 +401,12 @@ struct History: View {
                             .foregroundColor(Color("Gray500"))
                     }
                 }
-                
+
                 Spacer()
 
                 // 통증 레벨 바 표시
                 if vm.recentRecords.count < 2 {
-                    
+
                 } else if let first = vm.firstPainLevel,
                     let latest = vm.latestPainLevel
                 {
@@ -418,13 +436,14 @@ struct History: View {
                     }
 
                 }
-                
+
                 Spacer()
 
                 // 변화 설명 텍스트
                 Text(
                     vm.recentRecords.count < 2
-                        ? "첫 기록을 남겨보세요\nAnggle과 함께\n몸의 변화를 기록해봐요!" : vm.painChangeText
+                        ? "첫 기록을 남겨보세요\nAnggle과 함께\n몸의 변화를 기록해봐요!"
+                        : vm.painChangeText
                 )
                 .font(
                     vm.recentRecords.count < 2
@@ -475,6 +494,10 @@ struct HistoryPreviewWrapper: View {
                 }
         }
     }
+}
+
+#Preview("No Record") {
+    HistoryPreviewWrapper(scenario: .noRecord)
 }
 
 #Preview("Single Record") {

--- a/gacha/gacha/Views/DashBoard/History.swift
+++ b/gacha/gacha/Views/DashBoard/History.swift
@@ -42,10 +42,12 @@ struct History: View {
                             VStack(alignment: .leading, spacing: 16) {
 
                                 VStack(alignment: .leading, spacing: 8) {
+                                    // Title
                                     Text(Strings.History.romTitle)
                                         .font(.displayTitle3Bold)
                                         .id("romChart")
-                                    Text(Strings.History.romSubWorse)
+                                    // SubTitle
+                                    Text(vm.romSubtitle)
 
                                     romChart
 
@@ -59,10 +61,12 @@ struct History: View {
                             VStack(alignment: .leading, spacing: 16) {
                                 
                                 VStack(alignment: .leading, spacing: 8) {
+                                    // Title
                                     Text(Strings.History.painTitle)
                                         .font(.displayTitle3Bold)
                                         .id("painChart")
-                                    Text(Strings.History.painSubBetter)
+                                    // SubTitle
+                                    Text(vm.painSubtitle)
 
                                     painChart
                                 }

--- a/gacha/gacha/Views/DashBoard/History.swift
+++ b/gacha/gacha/Views/DashBoard/History.swift
@@ -41,11 +41,12 @@ struct History: View {
                             // MARK: - 무릎 가동범위 추이
                             VStack(alignment: .leading, spacing: 16) {
 
-                                Text(Strings.History.romTitle)
-                                    .font(.displayTitle3Bold)
-                                    .id("romChart")
+                                VStack(alignment: .leading, spacing: 8) {
+                                    Text(Strings.History.romTitle)
+                                        .font(.displayTitle3Bold)
+                                        .id("romChart")
+                                    Text(Strings.History.romSubWorse)
 
-                                VStack(alignment: .leading) {
                                     romChart
 
                                 }
@@ -56,11 +57,13 @@ struct History: View {
 
                             // MARK: - 통증 수준 추이
                             VStack(alignment: .leading, spacing: 16) {
-                                Text(Strings.History.painTitle)
-                                    .font(.displayTitle3Bold)
-                                    .id("painChart")
+                                
+                                VStack(alignment: .leading, spacing: 8) {
+                                    Text(Strings.History.painTitle)
+                                        .font(.displayTitle3Bold)
+                                        .id("painChart")
+                                    Text(Strings.History.painSubBetter)
 
-                                VStack(alignment: .leading) {
                                     painChart
                                 }
                                 .padding(16)
@@ -91,18 +94,15 @@ struct History: View {
         let selectedIndex = vm.selectedROMIndex
 
         return Chart {
+
             ForEach(data, id: \.record.id) { item in
                 BarMark(
                     x: .value("index", item.index),
                     y: .value("flexion", item.record.flexionAngle ?? 0),
-                    width: .fixed(6)
+                    width: .fixed(12)
                 )
                 .foregroundStyle(
-                    LinearGradient(
-                        colors: [Color("Blue500"), Color("Blue400")],
-                        startPoint: .top,
-                        endPoint: .bottom
-                    )
+                    Color("Blue500")
                 )
                 .cornerRadius(4)
             }
@@ -114,7 +114,7 @@ struct History: View {
                     .zIndex(-1)
                     .annotation(
                         position: .top,
-                        spacing: 0,
+                        spacing: 8,
                         overflowResolution: .init(
                             x: .fit(to: .chart),
                             y: .disabled
@@ -157,6 +157,7 @@ struct History: View {
         .chartXScale(domain: domain)
         .chartXSelection(value: $vm.selectedROMIndex)
         .frame(height: 361)
+        .padding(.top, 20)
     }
 
     @ViewBuilder
@@ -203,15 +204,15 @@ struct History: View {
                     x: .value("index", item.index),
                     y: .value("pain", item.record.painLevel ?? 0)
                 )
-                .foregroundStyle(Color("GraphSecondary"))
+                .foregroundStyle(Color(.blue500))
                 .interpolationMethod(.catmullRom)
 
                 PointMark(
                     x: .value("index", item.index),
                     y: .value("pain", item.record.painLevel ?? 0)
                 )
-                .foregroundStyle(Color("GraphSecondary"))
-                .symbolSize(60)
+                .foregroundStyle(Color("Blue500"))
+                .symbolSize(80)
             }
             
             if let selectedIndex = selectedIndex,
@@ -254,6 +255,7 @@ struct History: View {
         .chartXScale(domain: domain)
         .chartXSelection(value: $vm.selectedPainIndex)
         .frame(height: 250)
+        .padding(.top, 20)
     }
 
     @ViewBuilder

--- a/gacha/gacha/Views/DashBoard/History.swift
+++ b/gacha/gacha/Views/DashBoard/History.swift
@@ -22,62 +22,58 @@ struct History: View {
                 ScrollViewReader { proxy in
                     ScrollView {
                         VStack(spacing: 32) {
-                        
-                        HStack {
-                            Text(Strings.History.titleLarge)
-                                .font(.displayLargeBold)
-                            Spacer()
-                        }
-                        
 
-                        // MARK: - Summary Cards
-                        HStack(spacing: 14) {
-                            // 무릎 굽힘 범위 카드
-                            romSummaryCard(proxy: proxy)
-                            
-                            // 통증 정도 카드
-                            painSummaryCard(proxy: proxy)
-                        }
-                        
-                        
-                        // MARK: - 무릎 가동범위 추이
-                        VStack(alignment: .leading, spacing: 16) {
-                            
-                            Text(Strings.History.romTitle)
-                                .font(.displayTitle3Bold)
-                                .id("romChart")
-                            
-                            VStack(alignment: .leading) {
-                                romChart
-                                    
+                            HStack {
+                                Text(Strings.History.titleLarge)
+                                    .font(.displayLargeBold)
+                                Spacer()
                             }
-                            .padding(16)
-                            .background(Color("White"))
-                            .cornerRadius(24)
-                        }
-                
 
+                            // MARK: - Summary Cards
+                            HStack(spacing: 14) {
+                                // 무릎 굽힘 범위 카드
+                                romSummaryCard(proxy: proxy)
 
-                        // MARK: - 통증 수준 추이
-                        VStack(alignment: .leading, spacing: 16) {
-                            Text(Strings.History.painTitle)
-                                .font(.displayTitle3Bold)
-                                .id("painChart")
-                            
-                            VStack(alignment: .leading) {
-                                painChart
+                                // 통증 정도 카드
+                                painSummaryCard(proxy: proxy)
                             }
-                            .padding(16)
-                            .background(Color("White"))
-                            .cornerRadius(24)
+
+                            // MARK: - 무릎 가동범위 추이
+                            VStack(alignment: .leading, spacing: 16) {
+
+                                Text(Strings.History.romTitle)
+                                    .font(.displayTitle3Bold)
+                                    .id("romChart")
+
+                                VStack(alignment: .leading) {
+                                    romChart
+
+                                }
+                                .padding(16)
+                                .background(Color("White"))
+                                .cornerRadius(24)
+                            }
+
+                            // MARK: - 통증 수준 추이
+                            VStack(alignment: .leading, spacing: 16) {
+                                Text(Strings.History.painTitle)
+                                    .font(.displayTitle3Bold)
+                                    .id("painChart")
+
+                                VStack(alignment: .leading) {
+                                    painChart
+                                }
+                                .padding(16)
+                                .background(Color("White"))
+                                .cornerRadius(24)
+                            }
                         }
-                    }
-                    .padding(.horizontal, 20)
-                    .padding(.top, 60)
-                    .padding(.bottom, 20)
+                        .padding(.horizontal, 20)
+                        .padding(.top, 60)
+                        .padding(.bottom, 20)
                     }
                 }
-                 
+
             }
         }
         .background(Color("BackgoundSecondary"))
@@ -93,7 +89,7 @@ struct History: View {
         let data = vm.chartData
         let domain = vm.xAxisDomain
         let selectedIndex = vm.selectedROMIndex
-        
+
         return Chart {
             ForEach(data, id: \.record.id) { item in
                 BarMark(
@@ -296,7 +292,7 @@ struct History: View {
     @ViewBuilder
     private func romSummaryCard(proxy: ScrollViewProxy) -> some View {
         VStack {
-            VStack(alignment: .leading, spacing: 12) {
+            VStack(alignment: .leading) {
 
                 // 헤더
                 HStack {
@@ -305,9 +301,76 @@ struct History: View {
                         .foregroundColor(Color("Blue700"))
                     Spacer()
                     Button {
-                        withAnimation {
-                            proxy.scrollTo("romChart", anchor: .top)
-                        }
+                    } label: {
+                        Image(systemName: "chevron.right")
+                            .font(.system(size: 16, weight: .semibold))
+                            .foregroundColor(Color("Gray500"))
+                    }
+                }
+
+                Spacer()
+
+                // ROM 수치 표시
+                if vm.recentRecords.count < 2 {
+                    Text("측정일수 : \(vm.recentRecords.count)일")
+                        .font(.displayTitle3Semibold)
+                } else if let first = vm.firstROM, let latest = vm.latestROM {
+                    // 기록이 여러 개일 때
+                    HStack(spacing: 0) {
+                        Text("\(first)°")
+                            .font(.roundedTitle2Semibold)
+                            .foregroundColor(Color("Gray700"))
+
+                        Image(systemName: "arrow.right")
+                            .font(.roundedTitle2Semibold)
+                            .foregroundColor(Color("Gray700"))
+
+                        Text("\(latest)°")
+                            .font(.roundedLargeSemibold)
+                            .foregroundColor(Color("Gray900"))
+                    }
+
+                }
+
+                Spacer()
+
+                // 변화 설명 텍스트
+                Text(
+                    vm.recentRecords.count < 2
+                        ? "3일째 측정부터\n변화를 확인할 수 있어요!" : vm.romChangeText
+                )
+                .font(
+                    vm.recentRecords.count < 2
+                        ? .displayFootnoteRegular : .displayCalloutRegular
+                )
+                .foregroundColor(Color("Gray700"))
+                .lineLimit(3)
+
+            }
+            .padding(.horizontal, 16)
+            .padding(.vertical, 16)
+        }
+        .frame(width: 173, height: 173)
+        .background(Color.white)
+        .cornerRadius(15)
+        .onTapGesture {
+            withAnimation {
+                proxy.scrollTo("romChart", anchor: .top)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func painSummaryCard(proxy: ScrollViewProxy) -> some View {
+        VStack {
+            VStack(alignment: .leading) {
+                // 헤더
+                HStack {
+                    Text(Strings.History.painTitle)
+                        .font(.displayBodyBold)
+                        .foregroundColor(Color("Blue700"))
+                    Spacer()
+                    Button {
                     } label: {
                         Image(systemName: "chevron.right")
                             .font(.system(size: 16, weight: .semibold))
@@ -315,134 +378,68 @@ struct History: View {
                     }
                 }
                 
-                
-                
-                // ROM 수치 표시
-                if vm.recentRecords.count == 1 {
-                    // 기록이 1개만 있을 때
-                    if let rom = vm.firstROM {
-                        Text("\(rom)°")
-                            .font(.system(size: 36, weight: .bold))
-                            .foregroundColor(Color("Gray900"))
-                            .padding(.horizontal, 16)
-                    }
-                } else if let first = vm.firstROM, let latest = vm.latestROM {
-                    // 기록이 여러 개일 때
-                    HStack(spacing: 0) {
-                        Text("\(first)°")
-                            .font(.roundedTitle2Semibold)
-                            .foregroundColor(Color("Gray700"))
-                        
-                        Image(systemName: "arrow.right")
-                            .font(.roundedTitle2Semibold)
-                            .foregroundColor(Color("Gray700"))
-                        
-                        Text("\(latest)°")
-                            .font(.roundedLargeSemibold)
-                            .foregroundColor(Color("Gray900"))
-                    }
-                    
-
-                }
-                
-                // 변화 설명 텍스트
-                if !vm.romChangeText.isEmpty {
-                    Text(vm.romChangeText)
-                        .font(.displayBodyRegular)
-                        .foregroundColor(Color("Gray700"))
-                }
-                
-            }
-            .padding(.horizontal,8)
-            .padding(.vertical, 12)
-        }
-        .frame(width: 173, height: 173)
-        .background(Color.white)
-        .cornerRadius(15)
-    }
-    
-    @ViewBuilder
-    private func painSummaryCard(proxy: ScrollViewProxy) -> some View {
-        VStack {
-            VStack(alignment: .leading, spacing: 12) {
-            // 헤더
-            HStack {
-                Text(Strings.History.painTitle)
-                    .font(.displayBodyBold)
-                    .foregroundColor(Color("Blue700"))
                 Spacer()
-                Button {
-                    withAnimation {
-                        proxy.scrollTo("painChart", anchor: .top)
-                    }
-                } label: {
-                    Image(systemName: "chevron.right")
-                        .font(.system(size: 16, weight: .semibold))
-                        .foregroundColor(Color("Gray500"))
-                }
-            }
-            
-            // 통증 레벨 바 표시
-            if vm.recentRecords.count == 1 {
-                // 기록이 1개만 있을 때
-                if let pain = vm.firstPainLevel {
-                    VStack(alignment: .leading, spacing: 8) {
-                        HStack(spacing: 8) {
+
+                // 통증 레벨 바 표시
+                if vm.recentRecords.count < 2 {
+                    
+                } else if let first = vm.firstPainLevel,
+                    let latest = vm.latestPainLevel
+                {
+                    // 기록이 여러 개일 때
+                    VStack(alignment: .leading, spacing: 0) {
+                        // 첫 번째 통증 레벨
+                        HStack(spacing: 0) {
                             Rectangle()
-                                .fill(Color("Primary500"))
-                                .frame(width: CGFloat(pain) * 10, height: 8)
+                                .fill(Color("Blue900"))
+                                .frame(width: CGFloat(first) * 15, height: 3)
                                 .cornerRadius(4)
-                            Text("\(pain)")
-                                .font(.system(size: 24, weight: .bold))
+                            Text("\(first)")
+                                .font(.system(size: 17, weight: .bold))
+                                .foregroundColor(Color("Gray900"))
+                        }
+
+                        // 최근 통증 레벨
+                        HStack(spacing: 0) {
+                            Rectangle()
+                                .fill(Color("Blue700"))
+                                .frame(width: CGFloat(latest) * 15, height: 3)
+                                .cornerRadius(4)
+                            Text("\(latest)")
+                                .font(.system(size: 17, weight: .bold))
                                 .foregroundColor(Color("Gray900"))
                         }
                     }
 
                 }
-            } else if let first = vm.firstPainLevel, let latest = vm.latestPainLevel {
-                // 기록이 여러 개일 때
-                VStack(alignment: .leading, spacing: 0) {
-                    // 첫 번째 통증 레벨
-                    HStack (spacing: 0){
-                        Rectangle()
-                            .fill(Color("Blue900"))
-                            .frame(width: CGFloat(first) * 15, height: 3)
-                            .cornerRadius(4)
-                        Text("\(first)")
-                            .font(.system(size: 17, weight: .bold))
-                            .foregroundColor(Color("Gray900"))
-                    }
-                    
-                    // 최근 통증 레벨
-                    HStack (spacing: 0){
-                        Rectangle()
-                            .fill(Color("Blue700"))
-                            .frame(width: CGFloat(latest) * 15, height: 3)
-                            .cornerRadius(4)
-                        Text("\(latest)")
-                            .font(.system(size: 17, weight: .bold))
-                            .foregroundColor(Color("Gray900"))
-                    }
-                }
+                
+                Spacer()
 
+                // 변화 설명 텍스트
+                Text(
+                    vm.recentRecords.count < 2
+                        ? "첫 기록을 남겨보세요\nAnggle과 함께\n몸의 변화를 기록해봐요!" : vm.painChangeText
+                )
+                .font(
+                    vm.recentRecords.count < 2
+                        ? .displayFootnoteRegular : .displayCalloutRegular
+                )
+                .foregroundColor(Color("Gray700"))
+                .lineLimit(3)
             }
-            
-            // 변화 설명 텍스트
-            if !vm.painChangeText.isEmpty {
-                Text(vm.painChangeText)
-                    .font(.displayBodyRegular)
-                    .foregroundColor(Color("Gray700"))
-            }
-        }
-            .padding(.horizontal,8)
-            .padding(.vertical, 12)
-
+            .padding(.horizontal, 16)
+            .padding(.vertical, 16)
         }
         .frame(width: 173, height: 173)
         .background(Color.white)
         .cornerRadius(15)
+        .onTapGesture {
+            withAnimation {
+                proxy.scrollTo("painChart", anchor: .top)
+            }
+        }
     }
-    
+
     // MARK: - Helper Methods
     private func formatPainLevel(_ level: Int?) -> String {
         guard let level = level else { return "-" }
@@ -454,11 +451,15 @@ struct History: View {
 
 struct HistoryPreviewWrapper: View {
     @StateObject private var vm: HistoryViewModel
-    
+
     init(scenario: MockRecordRepository.Scenario) {
-        _vm = StateObject(wrappedValue: HistoryViewModel(repository: MockRecordRepository(scenario: scenario)))
+        _vm = StateObject(
+            wrappedValue: HistoryViewModel(
+                repository: MockRecordRepository(scenario: scenario)
+            )
+        )
     }
-    
+
     var body: some View {
         NavigationStack {
             History()

--- a/gacha/gacha/Views/Measure/MainViewBefore.swift
+++ b/gacha/gacha/Views/Measure/MainViewBefore.swift
@@ -57,7 +57,7 @@ struct MainViewBefore: View {
                     // 첫 번째 화면: "다음" 버튼 (light style, 100px cornerRadius)
                     CapsuleButtonComponent(
                         title: Strings.Button.next,
-                        style: .light,
+                        style: .secondary,
                         width: 361,
                         height: 54,
                         fontSize: 20,

--- a/gacha/gacha/en.lproj/Localizable.strings
+++ b/gacha/gacha/en.lproj/Localizable.strings
@@ -135,18 +135,18 @@
 "history.pain_subheadline_1record" = "Great first step!\nAnggle is cheering for you!";
 
 "history.rom_title" = "Flexion range";
-"history.rom_semibold15_better" = "You can flex (nn)° more than previous (nnn)°";
-"history.rom_semibold15_same" = "Same as the period’s max of (nnn)°";
-"history.rom_semibold15_worse" = "You moved (nnn)° less than previous (nnn)°";
+"history.rom_semibold15_better" = "You can flex %d° more than previous %d°";
+"history.rom_semibold15_same" = "Same as the period’s max of %d°";
+"history.rom_semibold15_worse" = "You moved %d° less than previous %d°";
 "history.rom_semibold15_norecord" = "Take your first measurement";
 "history.rom_semibold15_1record" = "Your knee can bend up to %d°";
 
 "history.pain_title" = "Pain Level";
-"history.pain_semibold15_better" = "Pain eased by (n) level from (nn)";
+"history.pain_semibold15_better" = "Pain eased by %d level from %d";
 "history.pain_semibold15_same" = "Same pain level as the previous lowest";
-"history.pain_semibold15_worse" = "Pain increased by (n) level from (nn)";
+"history.pain_semibold15_worse" = "Pain increased by %d level from %d";
 "history.pain_semibold15_norecord" = "Make your first record";
-"history.pain_semibold15_1record" = "You’re feeling pain at level %d"
+"history.pain_semibold15_1record" = "You’re feeling pain at level %d";
 
 /* History Summary Card - ROM Change */
 "history.rom_change_increased" = "It has improved by %d° over the past %d days!";

--- a/gacha/gacha/ko.lproj/Localizable.strings
+++ b/gacha/gacha/ko.lproj/Localizable.strings
@@ -135,18 +135,18 @@
 "history.pain_subheadline_1record" = "처음 기록을\n남기셨군요.\n\n회복을 향한 첫걸음을\nAnggle이 응원해요!";
 
 "history.rom_title" = "무릎 굽힘 범위";
-"history.rom_semibold15_better" = "이 기간 최대였던 nnn°보다 nnn° 더 움직일 수 있어요";
-"history.rom_semibold15_same" = "이 기간 최대였던 nnn°와 같아요";
-"history.rom_semibold15_worse" = "이 기간 최대였던 nnn°보다 nnn° 덜 움직여요";
+"history.rom_semibold15_better" = "이 기간 최대였던 %d°보다 %d° 더 움직일 수 있어요";
+"history.rom_semibold15_same" = "이 기간 최대였던 %d°와 같아요";
+"history.rom_semibold15_worse" = "이 기간 최대였던 %d°보다 %d° 덜 움직여요";
 "history.rom_semibold15_norecord" = "첫 측정을 완료해 주세요";
 "history.rom_semibold15_1record" = "현재 무릎이 %d°까지 굽혀지고 있어요";
 
 "history.pain_title" = "통증 정도";
-"history.pain_semibold15_better" = "이 기간 가장 낮았던  nn보다 n단계 덜 아파졌어요";
-"history.pain_semibold15_same" = "이기간 가장 낮았던 nn단계의 통증과 같아요";
-"history.pain_semibold15_worse" = "이 기간 가장 낮았던 nn보다 n단계 더 아파졌어요";
+"history.pain_semibold15_better" = "이 기간 가장 낮았던 %d보다 %d단계 덜 아파졌어요";
+"history.pain_semibold15_same" = "이기간 가장 낮았던 %d단계의 통증과 같아요";
+"history.pain_semibold15_worse" = "이 기간 가장 낮았던 %d보다 %d단계 더 아파졌어요";
 "history.pain_semibold15_norecord" = "첫 기록을 남겨 주세요";
-"history.pain_semibold15_1record" = "현재 통증 정도는 %d단계예요"
+"history.pain_semibold15_1record" = "현재 통증 정도는 %d단계예요";
 
 /* History Summary Card - ROM Change */
 "history.rom_change_increased" = "지난 %d일간\n무릎 굽힘 범위가\n%d도 늘어났어요!";


### PR DESCRIPTION
<!--
🙏 PR 제목 컨벤션 (Gitmoji + 타입 + 이슈 번호 + 작업 요약)
예시: ✨ Feature: #167 예약 취소 구현
※ PR 생성 시 Assignees 및 Labels 설정도 잊지 마세요!
-->

## ✨ What’s this PR?
### 📌 관련 이슈 (Related Issue)
<!-- 해당 PR이 어떤 이슈를 해결하는지 연결해주세요 -->
- Closes #98 

---

### 🧶 주요 변경 내용 (Summary)
<!-- 이번 PR에서 작업한 핵심 변경 사항을 작성해주세요 -->

- 요약뷰 카드 컴포넌트 버튼처리 및 초기 문구 추가
- 요약뷰 차트에서 상세보기가 잘리는 오류 해결
- 요약뷰 차트에서 데이터가 없을 시의 디자인 반영
- 다시 측정 > 통증 입력 시 데이터 저장 안되는 오류 해결
- 측정뷰의 "다음" 버튼 색상 변경

---

### 📸 스크린샷 (Optional)
<!-- UI 작업의 경우, 구현한 화면을 첨부해주세요 -->
<!-- 이미지 크기 조절 예시: <img width="300" alt="설명" src="링크"> -->

<img width="300" height="800" alt="image" src="https://github.com/user-attachments/assets/aac664db-8f13-4784-8d5f-f6bf1f9a18eb" /> 
<img width="300" height="800" alt="image" src="https://github.com/user-attachments/assets/6c59e1bc-3723-4417-b230-263d629861ca" />

---

### 🧪 테스트 / 검증 내역
<!-- 동작 확인 여부나 시나리오 테스트 내용을 간단히 써주세요 -->

- [x] 빌드 및 런타임 오류 없음
- [x] 기기 테스트 완료
- [x] PR 제목 컨벤션 지킴
- [x] 불필요한 코드 제거
- [x] 리뷰 준비 완료

