### PR TITLE
🎨 Design: 측정 종류 선택 불가 알림 추가

### DIFF
--- a/gacha/gacha/LocalStrings.swift
+++ b/gacha/gacha/LocalStrings.swift
@@ -58,6 +58,10 @@ enum Strings {
         static var cancelPainMessage: String { NSLocalizedString("alert.cancel.pain.message", comment: "") }
         static var remeasureTitle: String { NSLocalizedString("alert.remeasure.title", comment: "") }
         static var remeasureMessage: String { NSLocalizedString("alert.remeasure.message", comment: "") }
+        static var notyetTitle: String { NSLocalizedString("alert.notyet.title", comment: "")
+        }
+        static var notyetMessage: String { NSLocalizedString("alert.notyet.message", comment: "")
+        }
     }
     
     // MARK: - MainBefore

--- a/gacha/gacha/LocalStrings.swift
+++ b/gacha/gacha/LocalStrings.swift
@@ -41,6 +41,7 @@ enum Strings {
         static var painOnly: String { NSLocalizedString("button.pain_only", comment: "") }
         static var save: String { NSLocalizedString("button.save", comment: "") }
         static var cancel: String { NSLocalizedString("button.cancel", comment: "") }
+        static var back: String { NSLocalizedString("button.back", comment: "") }
     }
     
     // MARK: - Tabbar
@@ -161,7 +162,6 @@ enum Strings {
         
         static var betterNoPainTitle: String { NSLocalizedString("progress.better_nopain.title", comment: "") }
         static var betterNoPainDescription: String { NSLocalizedString("progress.better_nopain.description", comment: "") }
-        
         static var betterMildPainTitle: String { NSLocalizedString("progress.better_mildpain.title", comment: "") }
         static var betterMildPainDescription: String { NSLocalizedString("progress.better_mildpain.description", comment: "") }
         

--- a/gacha/gacha/en.lproj/Localizable.strings
+++ b/gacha/gacha/en.lproj/Localizable.strings
@@ -1,10 +1,10 @@
 /*
-   Localizable.strings
-   gacha
+    Localizable.strings
+    gacha
  
-   Created by 김순주 on 11/15/25.
+    Created by 김순주 on 11/15/25.
  
-   */
+    */
 
 /* Common */
 "common.yes" = "Yes";
@@ -31,11 +31,13 @@
 "alert.cancel.flexion.message" = "Return to the first screen";
 "alert.cancel.pain.title" = "Cancel pain record?";
 "alert.cancel.pain.message" = "Return to the first screen";
-"alert.remeasure.title" = "Measure again?";
-"alert.remeasure.message" = "The new measurement will update today's record";
+"alert.remeasure.title" = "Measure knee again?";
+"alert.remeasure.message" = "This will update today’s record";
+"alert.notyet.title" = "Not available yet";
+"alert.notyet.message" = "It’ll be ready soon";
 
 /* MainBefore - 1/2 */
-"daily_start.title" = "Prepare to Measure";
+"daily_start.title" = "Ready for Knee Flexion";
 "daily_start.instruction.no1" = "Sit and bend your knee fully";
 "daily_start.instruction.no2" = "Place iPhone on thigh near the knee";
 "daily_start.instruction.no3" = "Hold still until measurement ends";

--- a/gacha/gacha/en.lproj/Localizable.strings
+++ b/gacha/gacha/en.lproj/Localizable.strings
@@ -20,6 +20,7 @@
 "button.pain_only" = "Enter Pain Only";
 "button.save" = "Save";
 "button.cancel" = "Cancel";
+"button.back" = "Back";
 
 /* Tabbar */
 "tabbar.calendar" = "Calendar";
@@ -86,7 +87,6 @@
 
 "progress.better_nopain.title" = "Recovery Going Well";
 "progress.better_nopain.description" = "Movement is smooth.\nNo pain, recovery is progressing.";
-
 "progress.better_mildpain.title" = "Positive Progress";
 "progress.better_mildpain.description" = "Slight stiffness is okay.\nMove slowly and steadily.";
 "progress.better_moderatepain.title" = "Check with Specialist";

--- a/gacha/gacha/ko.lproj/Localizable.strings
+++ b/gacha/gacha/ko.lproj/Localizable.strings
@@ -1,10 +1,10 @@
 /*
-   Localizable.strings
-   gacha
+    Localizable.strings
+    gacha
  
-   Created by 김순주 on 11/15/25.
+    Created by 김순주 on 11/15/25.
  
-   */
+    */
 
 /* Common */
 "common.yes" = "네";
@@ -31,11 +31,13 @@
 "alert.cancel.flexion.message" = "처음 화면으로 되돌아가요";
 "alert.cancel.pain.title" = "통증 기록을 취소하시겠어요?";
 "alert.cancel.pain.message" = "처음 화면으로 되돌아가요";
-"alert.remeasure.title" = "다시 측정하시겠어요?";
-"alert.remeasure.message" = "새로 측정한 내용이 오늘의 기록으로 업데이트되어 저장돼요.";
+"alert.remeasure.title" = "무릎 측정을 다시 하시겠어요?";
+"alert.remeasure.message" = "새로 측정한 각도가 오늘 기록으로 저장돼요";
+"alert.notyet.title" = "아직 이 측정은 열려 있지 않아요";
+"alert.notyet.message" = "곧 측정할 수 있도록 준비할게요";
 
 /* MainBefore - 1/2 */
-"daily_start.title" = "측정 준비하기";
+"daily_start.title" = "무릎 굽힘 측정 준비";
 "daily_start.instruction.no1" = "측정할 무릎을 최대한 굽혀 앉아주세요";
 "daily_start.instruction.no2" = "iPhone을 무릎 쪽 허벅지에 얹어주세요";
 "daily_start.instruction.no3" = "측정이 끝날 때까지 자세를 유지하세요";

--- a/gacha/gacha/ko.lproj/Localizable.strings
+++ b/gacha/gacha/ko.lproj/Localizable.strings
@@ -20,6 +20,7 @@
 "button.pain_only" = "통증 수치만 입력하기";
 "button.save" = "저장";
 "button.cancel" = "취소";
+"button.back" = "뒤로";
 
 /* tabbar */
 "tabbar.calendar" = "기록";
@@ -86,7 +87,6 @@
 
 "progress.better_nopain.title" = "잘 회복되고 있어요";
 "progress.better_nopain.description" = "움직임이 부드러워졌어요.\n통증도 없고 회복이 잘되고 있어요.\n이대로 꾸준히 이어가요.";
-
 "progress.better_mildpain.title" = "좋은 변화가 보여요";
 "progress.better_mildpain.description" = "조금 뻐근할 수 있지만 괜찮아요.\n지금처럼 천천히 해요.\n무리하지 않는 게 중요해요.";
 "progress.better_moderatepain.title" = "전문가와 함께 점검해 보세요";


### PR DESCRIPTION
🎨 Design: 측정 종류 선택 불가 알림 추가

## ✨ What’s this PR?
### 📌 관련 이슈 (Related Issue)
- Closes #128

---

### 🧶 주요 변경 내용 (Summary)

- 측정 종류 선택 불가 알림 추가
- "측정 종류 명시 : "무릎 굽힘 측정"
-"뒤로" 버튼 추가

---

### 📸 스크린샷 (Optional)
<!-- UI 작업의 경우, 구현한 화면을 첨부해주세요 -->
<!-- 이미지 크기 조절 예시: <img width="300" alt="설명" src="링크"> -->

<img width="300" alt="예시 이미지" src="https://...">

---

### 🧪 테스트 / 검증 내역
<!-- 동작 확인 여부나 시나리오 테스트 내용을 간단히 써주세요 -->

- [ ] 빌드 및 런타임 오류 없음
- [ ] 기기 테스트 완료
- [ ] PR 제목 컨벤션 지킴
- [ ] 불필요한 코드 제거
- [ ] 리뷰 준비 완료

---

### 💬 기타 공유 사항
<!-- 리뷰어가 참고하면 좋을 정보, 고민했던 지점 등을 적어주세요 -->

- UI 컴포넌트 위치가 디자이너 시안과 다를 수 있어요 → 후속 PR에서 반영 예정
- API 에러 대응 로직은 공통 모듈화하는 작업과 함께 처리할 예정입니다

---

### 🙇🏻‍♀️ 리뷰 가이드 (선택)
<!-- 리뷰어가 중점적으로 보면 좋을 포인트가 있다면 알려주세요 -->

- `XxxViewModel.swift` 파일의 로직 분리 구조
- `NetworkManager.swift`의 공통 로직 처리 방식
